### PR TITLE
Fixes MAX_NR_CONNECTIONS check

### DIFF
--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.cpp
@@ -418,7 +418,7 @@ void Ocp1LiteNetwork::HandleSelectables(const OcfLiteSelectableSet& readSet,
         // the keep alive timeout.
         ::OcaSessionID newSessionID(::OcaLiteCommandHandler::GetInstance().CreateSessionID());
         ::Ocp1LiteSocketConnection* sConnection(new ::Ocp1LiteSocketConnection(*this, static_cast< ::OcaUint32>(OCA_BUFFER_SIZE)));
-        if ((OCA_INVALID_SESSIONID != newSessionID) && (m_ocaSocketList.size() <= OCP1_MAX_NR_CONNECTIONS))
+        if ((OCA_INVALID_SESSIONID != newSessionID) && (m_ocaSocketList.size() < OCP1_MAX_NR_CONNECTIONS))
         {
             sConnection->SetSocketConnectionParameters(newSessionID, static_cast< ::OcaUint16>(0));
 


### PR DESCRIPTION
In the method HandleSelectables there is checked if (m_ocaSocketList.size() <= OCP1_MAX_NR_CONNECTIONS) but it should be  (m_ocaSocketList.size() < OCP1_MAX_NR_CONNECTIONS) because with "less or equal than" there will be still accepted an incoming connection even e.g. in case you have already 2 connections and the max number of connections is 2.  