### PR TITLE
Remove assert preventing serializing Null Method values

### DIFF
--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.cpp
@@ -66,8 +66,6 @@ bool OcaLiteMessageNotification::WriteParameters(::OcaONo targetONo,
 void OcaLiteMessageNotification::WriteParameters(::OcaONo targetONo,
                                                  const ::OcaLiteMethodID& methodID)
 {
-    assert(OCA_INVALID_ONO != targetONo);
-
     m_targetONo = targetONo;
     m_methodID = methodID;
 }


### PR DESCRIPTION
Noticed this assert was being hit when using lightweight subscriptions, in which the subscriber parameter is allowed to be an OcaMethod with all fields set to zero, so have removed the assertion.