### PR TITLE
Update license header comments

### DIFF
--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
  /*

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The logging implementation of the Host Interface for
  *                        a OcaLite enabled platform.

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLite Ocp1Service implementation.
  *

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/BaseTestClass.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/BaseTestClass.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Base class for a test case
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/BaseTestClass.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/BaseTestClass.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Base class for tests.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestContext.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestContext.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test suite
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestContext.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestContext.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The TestContext class.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestLogger.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test logger
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestLogger.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestLogger.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Base class for tests.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestSuite.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestSuite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test suite
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestSuite.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/TestFramework/TestSuite.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The TestSuite class.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/DummyTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/DummyTest.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Dummy test class.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/MinimumObjectCompliancyTest/MinimumObjectCompliancyTest.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/MinimumObjectCompliancyTest/MinimumObjectCompliancyTest.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test Minimum Object Compliancy
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/MinimumObjectCompliancyTest/MinimumObjectCompliancyTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/MinimumObjectCompliancyTest/MinimumObjectCompliancyTest.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : The minimum object compliancy test class.
 */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCC/ObjectCompliancyTest.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCC/ObjectCompliancyTest.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test Object Compliancy
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCC/ObjectCompliancyTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCC/ObjectCompliancyTest.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : The Object compliancy test class.
 */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceResetTest.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceResetTest.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Device reset test
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceResetTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceResetTest.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The device reset test class.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceServiceDiscoveryTest.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceServiceDiscoveryTest.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test Device Service Discovery
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceServiceDiscoveryTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/DeviceServiceDiscoveryTest.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : The Device service registration test class.
 */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/KeepAliveTest.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/KeepAliveTest.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Test suite
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/KeepAliveTest.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/Tests/OCP.1/KeepAliveTest.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The keep alive test class.
  */

--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/VersionDefs.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/VersionDefs.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Version file
  *

--- a/OCACompliancyTestTool/Aes70CompliancyTestToolConsoleDocumentation.h
+++ b/OCACompliancyTestTool/Aes70CompliancyTestToolConsoleDocumentation.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Compliancy test tool documentation
  */

--- a/OCACompliancyTestTool/DNSSDResolver/DNSSDResolver.cpp
+++ b/OCACompliancyTestTool/DNSSDResolver/DNSSDResolver.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLite DNSSDResolver implementation.
  *

--- a/OCACompliancyTestTool/DNSSDResolver/DNSSDResolver.h
+++ b/OCACompliancyTestTool/DNSSDResolver/DNSSDResolver.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The DNSSDResolver class.
  */

--- a/OCACompliancyTestTool/DNSSDResolver/ResolveResult.cpp
+++ b/OCACompliancyTestTool/DNSSDResolver/ResolveResult.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLite ResolveResult implementation.
  *

--- a/OCACompliancyTestTool/DNSSDResolver/ResolveResult.h
+++ b/OCACompliancyTestTool/DNSSDResolver/ResolveResult.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The ResolveResult class.
  */

--- a/OCACompliancyTestTool/Installer/CommonChecks/CustomActions.cs
+++ b/OCACompliancyTestTool/Installer/CommonChecks/CustomActions.cs
@@ -1,5 +1,6 @@
 ﻿/*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 using Microsoft.Deployment.WindowsInstaller;
 using System;

--- a/OCACompliancyTestTool/Installer/CommonChecks/Properties/AssemblyInfo.cs
+++ b/OCACompliancyTestTool/Installer/CommonChecks/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿/*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/OCACompliancyTestTool/build.cmd
+++ b/OCACompliancyTestTool/build.cmd
@@ -1,5 +1,6 @@
 :: By downloading or using this file, the user agrees to be bound by the terms of the license 
-:: agreement located at http://ocaalliance.com/EULA as an original contracting party.
+:: agreement located in the LICENSE file in the root of this project
+:: as an original contracting party.
 @echo off
 
 :: TODO write the BUILD_VERSION in the version file on bases of the commit.

--- a/OCAMicro/Application/inc/i2c_handler.h
+++ b/OCAMicro/Application/inc/i2c_handler.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //=========================================================================

--- a/OCAMicro/Application/inc/mac_addr.h
+++ b/OCAMicro/Application/inc/mac_addr.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //=========================================================================

--- a/OCAMicro/Application/inc/main.h
+++ b/OCAMicro/Application/inc/main.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/

--- a/OCAMicro/Application/inc/persist.h
+++ b/OCAMicro/Application/inc/persist.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //=============================================================================

--- a/OCAMicro/Application/inc/rowley_locks.h
+++ b/OCAMicro/Application/inc/rowley_locks.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //=========================================================================

--- a/OCAMicro/Application/inc/version.h
+++ b/OCAMicro/Application/inc/version.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //============================================================================

--- a/OCAMicro/Application/src/encoder.c
+++ b/OCAMicro/Application/src/encoder.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/i2c1_handler.c
+++ b/OCAMicro/Application/src/i2c1_handler.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/led_matrix.c
+++ b/OCAMicro/Application/src/led_matrix.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/mac_addr.c
+++ b/OCAMicro/Application/src/mac_addr.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/main.cpp
+++ b/OCAMicro/Application/src/main.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/persist.c
+++ b/OCAMicro/Application/src/persist.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/rowley_locks.c
+++ b/OCAMicro/Application/src/rowley_locks.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/serial_debug_task.c
+++ b/OCAMicro/Application/src/serial_debug_task.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/stm32f2x7_eth_bsp.c
+++ b/OCAMicro/Application/src/stm32f2x7_eth_bsp.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/switch_processing.cpp
+++ b/OCAMicro/Application/src/switch_processing.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/Application/src/usart1handler.c
+++ b/OCAMicro/Application/src/usart1handler.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
  /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALite/OCALite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/OCALite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/OCAMicro/Src/app/OCALite/makefile
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCALite proto
 #

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/OCALiteController.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/OCALiteController.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  */
 

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/makefile
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCALite Proto Controller
 #

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteConMon.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteConMon.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 // DanteLiteConMon.cpp : Dante Connection Manager for local and remote subscriptions

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteConMon.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteConMon.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Dante ConMon Implementation Interface
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteHostInterface.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteHostInterface.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteHostInterface.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/DanteLiteHostInterface.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The dante configuration interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OCALiteDante.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OCALiteDante.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 // OCALite.cpp : Defines the entry point for the console application.

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OCALiteOCCFactory.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OCALiteOCCFactory.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 // OCALiteOCCFactory.cpp : Simple stub that creates and destroys the Lite objects for the reference design.

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteLvlSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteLvlSensor.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCALiteDanteLvlSensor
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteLvlSensor.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteLvlSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCALiteDanteLvlSensor
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteMediaClock.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteMediaClock.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : DanteLiteOcaMediaClock
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteMediaClock.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteDanteMediaClock.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Dante Media Clock Implementation
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteNetworkSignalChannelDante.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteNetworkSignalChannelDante.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSignalChannelDante
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteNetworkSignalChannelDante.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteNetworkSignalChannelDante.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSignalChannel
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteStreamNetworkDante.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteStreamNetworkDante.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStreamNetworkDante
  *

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteStreamNetworkDante.h
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/OcaLiteStreamNetworkDante.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStreamNetwork
  *

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/OCALite.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/OCALite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 // OCALite.cpp : Defines the entry point for the console application.

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/makefileBIN
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/makefileBIN
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCALite BKNII
 #

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/makefileLIB
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/makefileLIB
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCALite BKNII
 #

--- a/OCAMicro/OCAMicro/Src/app/OCA_PI/makefileBIN
+++ b/OCAMicro/OCAMicro/Src/app/OCA_PI/makefileBIN
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCA PI
 #

--- a/OCAMicro/OCAMicro/Src/app/OCA_PI/makefileLIB
+++ b/OCAMicro/OCAMicro/Src/app/OCA_PI/makefileLIB
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCA PI
 #

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/Board Support Packages/OCAStm32F207xxOcaLite/makefile
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/Board Support Packages/OCAStm32F207xxOcaLite/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCAStm32F207xxOcaLite Board Support Package.
 # 

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/Board Support Packages/makefile
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/Board Support Packages/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Stm32
 #

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/OCALitePrototype.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/OCALitePrototype.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCALite Proto Application
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PILEDBitStringActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PILEDBitStringActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PILEDBitStringActuator.h
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PILEDBitStringActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PILEDBitStringActuator class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIRELAYBooleanActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIRELAYBooleanActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PIRelayBooleanActuator class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIRELAYBooleanActuator.h
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIRELAYBooleanActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PIRelayBooleanActuator class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchBitStringSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchBitStringSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PISwitchBitStringSensor class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchBitStringSensor.h
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchBitStringSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PISwitchBitStringSensor class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchLedBitStringActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchLedBitStringActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchLedBitStringActuator.h
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PISwitchLedBitStringActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PISwitchLedBitStringActuator class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIencoderInt8Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIencoderInt8Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIencoderInt8Sensor.h
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/PIencoderInt8Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The PIencoderInt8Sensor class.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/ReducedStdLib.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/ReducedStdLib.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Contains basic routines to prevent need for stdlib calls.
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/Stm32Interrupts.cpp
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/Stm32Interrupts.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Cortex-M4 Processor Exceptions Handlers 
  *

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/newlib_stubs.c
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/OCALitePrototype/newlib_stubs.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/makefile
+++ b/OCAMicro/OCAMicro/Src/app/Stm32CortexM3/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Stm32CortexM3 
 #

--- a/OCAMicro/OCAMicro/Src/app/makefile
+++ b/OCAMicro/OCAMicro/Src/app/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for applications
 #

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/AES67/AES67LiteHostInterface.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/AES67/AES67LiteHostInterface.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The AES67 configuration interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Configuration/IOcfLiteConfigure.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Configuration/IOcfLiteConfigure.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The device configuration interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Logging/IOcfLiteLog.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Logging/IOcfLiteLog.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The logging interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/OcfLiteHostInterface.cpp
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/OcfLiteHostInterface.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/OcfLiteHostInterface.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/OcfLiteHostInterface.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The entry point to the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Selection/OcfLiteSelectableSet.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Selection/OcfLiteSelectableSet.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : A set of selectable objects.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Timer/IOcfLiteTimer.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCF/Timer/IOcfLiteTimer.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The timer interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Network/IOcp1LiteNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Network/IOcp1LiteNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The network configuration interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Network/IOcp1LiteSocket.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Network/IOcp1LiteSocket.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Socket interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterface.cpp
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterface.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterface.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterface.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The entry point to the OCP.1 Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterfaceConstants.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterfaceConstants.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Constants used in the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterfaceDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/Ocp1LiteHostInterfaceDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Host Interface specific data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/ZeroConf/IOcp1LiteService.h
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/OCA/OCP.1/ZeroConf/IOcp1LiteService.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Service interface of the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/makefile
+++ b/OCAMicro/OCAMicro/Src/common/HostInterfaceLite/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the HostInterface
 #

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteAgent.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteAgent.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteAgent
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteAgent.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteAgent.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaAgent
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaClock
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock3.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock3.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock3.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteMediaClock3.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaClock3
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteNetwork.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamConnector.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamConnector.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStreamConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamConnector.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamConnector.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaStreamConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamNetwork.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStreamNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteStreamNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStreamNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteTimeSource.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteTimeSource.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteTimeSource
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteTimeSource.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Agents/OcaLiteTimeSource.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteTimeSource
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteDeviceManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceTimeManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceTimeManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceTimeManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteDeviceTimeManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteDeviceTimeManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteFirmwareManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteFirmwareManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteFirmwareManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteFirmwareManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaFirmwareManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteMediaClockManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteMediaClockManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteMediaClockManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteMediaClockManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaClockManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteNetworkManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteNetworkManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteNetworkManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteNetworkManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkManager
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteSubscriptionManager.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteSubscriptionManager.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteSubscriptionManager.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Managers/OcaLiteSubscriptionManager.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteSubscriptionManager class.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteApplicationNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteApplicationNetwork.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteApplicationNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteApplicationNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteApplicationNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteApplicationNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetwork.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaTransportNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaTransportNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetworkAES67.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetworkAES67.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaTransportNetworkAes67
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetworkAES67.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Networks/OcaLiteMediaTransportNetworkAES67.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaTransportNetworkAes67
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/OcaLiteRoot.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/OcaLiteRoot.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/OcaLiteRoot.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/OcaLiteRoot.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteRoot
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteActuator
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBasicActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBasicActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBasicActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBasicActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBasicActuator
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBitstringActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBitstringActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBitstringActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBitstringActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBitstringActuator
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBooleanActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBooleanActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBooleanActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteBooleanActuator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBooleanActuator
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteDelay.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteDelay.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
  /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteDelay.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteDelay.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteDelay
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteFloat32Actuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteFloat32Actuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteFloat32Actuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteFloat32Actuator.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteFloat32Actuator
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteGain.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteGain.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteGain.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteGain.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteGain
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteIdentificationActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteIdentificationActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteIdentificationActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteIdentificationActuator.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteIdentificationActuator
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteInt32Actuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteInt32Actuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteInt32Actuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteInt32Actuator.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteInt32Actuator
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteMute.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteMute.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteMute.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteMute.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMute
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteStringActuator.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteStringActuator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteStringActuator.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteStringActuator.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteStringActuator
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteSwitch.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteSwitch.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteSwitch.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Actuators/OcaLiteSwitch.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteSwitch
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/BlocksAndMatrices/OcaLiteBlock.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/BlocksAndMatrices/OcaLiteBlock.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/BlocksAndMatrices/OcaLiteBlock.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/BlocksAndMatrices/OcaLiteBlock.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBlock
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Networking/OcaLiteNetworkSignalChannel.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Networking/OcaLiteNetworkSignalChannel.cpp
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSignalChannel
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Networking/OcaLiteNetworkSignalChannel.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Networking/OcaLiteNetworkSignalChannel.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSignalChannel
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/OcaLiteWorker.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/OcaLiteWorker.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/OcaLiteWorker.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/OcaLiteWorker.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaWorker
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBasicSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBasicSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBasicSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBasicSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBasicSensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBitstringSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBitstringSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBitstringSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBitstringSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBitstringSensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBooleanSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBooleanSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBooleanSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteBooleanSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBooleanSensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteFloat32Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteFloat32Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteFloat32Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteFloat32Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteInt8Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt16Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt16Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt16Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt16Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteInt16Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt32Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt32Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt32Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt32Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteInt32Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt64Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt64Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt64Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt64Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteInt64Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt8Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt8Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt8Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteInt8Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteInt8Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteLevelSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteLevelSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteLevelSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteLevelSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteLevelSensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteSensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteSensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteStringSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteStringSensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteStringSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteStringSensor.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteTemperatureSensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteTemperatureSensor.cpp
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteTemperatureSensor
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteTemperatureSensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteTemperatureSensor.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteTemperatureSensor
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint16Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint16Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint16Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint16Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteUint16Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint32Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint32Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint32Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint32Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteUInt32Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint64Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint64Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint64Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint64Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteUint64Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint8Sensor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint8Sensor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint8Sensor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlClasses/Workers/Sensors/OcaLiteUint8Sensor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteUint8Sensor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/IOcaLiteMarshal.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/IOcaLiteMarshal.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The IOcaLiteMarshal interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteAES67NetworkAddress.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteAES67NetworkAddress.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteAES67NetworkAddress
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteAES67NetworkAddress.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteAES67NetworkAddress.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteApplicationNetworkDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteApplicationNetworkDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC application network data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteApplicationNetworkDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteApplicationNetworkDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC network data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBaseDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBaseDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC base data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBitstring.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBitstring.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBitstring.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBitstring.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBitstring
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlob.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlob.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlob.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlob.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBlob
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobDataType.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobDataType.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobDataType.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobDataType.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBlobDataType
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobFixedLen.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobFixedLen.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobFixedLen.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlobFixedLen.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBlobFixedLen
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlockMember.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlockMember.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlockMember.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteBlockMember.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteBlockMember
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteClassID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassIdentification.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassIdentification.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassIdentification.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteClassIdentification.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteClassIdentification
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteConnectParameters.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteConnectParameters.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteConnectParameters
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteConnectParameters.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteConnectParameters.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteConnectParameters class.
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEvent.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEvent.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEvent.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEvent.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteEvent
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventData.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventData.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventData.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventData.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteEventID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventSubscriptionDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventSubscriptionDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventSubscriptionDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteEventSubscriptionDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC event and subscription data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteFrameworkDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteFrameworkDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteFrameworkDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteFrameworkDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC framework data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteList.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteList.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteList.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteList.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteList
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagementDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagementDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagementDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagementDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC management data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagerDescriptor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagerDescriptor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagerDescriptor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteManagerDescriptor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteManagerDescriptor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMap.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMap.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMap
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMap.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMap.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMap
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaClockRate.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaClockRate.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaClockRate.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaClockRate.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaClockRate
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaCoding.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaCoding.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaCoding
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaCoding.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaCoding.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteMediaCoding
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnection.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnection.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaConnection
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnection.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnection.h
@@ -1,6 +1,7 @@
 /*
 *  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteMediaConnection
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatus.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatus.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaConnectorStatus
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatus.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatus.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaConnectorStatus
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatusChangedEventData.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatusChangedEventData.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaConnectorStatusChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatusChangedEventData.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaConnectorStatusChangedEventData.h
@@ -1,6 +1,7 @@
 /*  
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaConnectorStatusChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnector.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnector.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSinkConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnector.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnector.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSinkConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnectorChangedEventData.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnectorChangedEventData.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
-*  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+*  agreement located in the LICENSE file in the root of this project
+*  as an original contracting party.
 *
 *  Description         : OcaLiteMediaSinkConnectorChangedEventData
 *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnectorChangedEventData.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSinkConnectorChangedEventData.h
@@ -1,6 +1,7 @@
 /*  
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSinkConnectorChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnector.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnector.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSourceConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnector.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnector.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSourceConnector
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnectorChangedEventData.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnectorChangedEventData.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSourceConnectorChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnectorChangedEventData.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaSourceConnectorChangedEventData.h
@@ -1,6 +1,7 @@
 /*  
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaSourceConnectorChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParameters.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParameters.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaStreamParameters
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParameters.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParameters.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaStreamParameters
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParametersAes67.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParametersAes67.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaStreamParametersAes67
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParametersAes67.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMediaStreamParametersAes67.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMediaStreamParametersAes67
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethod.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethod.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethod.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethod.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMethod
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethodID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethodID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethodID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMethodID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMethodID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelDescription.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelDescription.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelDescription.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelDescription.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteModelDescription
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelGUID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelGUID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelGUID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteModelGUID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteModelGUID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMultiMap.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMultiMap.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMultiMap
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMultiMap.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteMultiMap.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMultiMap
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkAddress.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkAddress.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkAddress.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkAddress.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkAddress
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC network data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC network data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkStatistics.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkStatistics.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkStatistics.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkStatistics.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkStatistics
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceDescriptor.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceDescriptor.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceDescriptor.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceDescriptor.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSystemInterfaceDescriptor
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteNetworkSystemInterfaceID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteNetworkSystemInterfaceID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteObjectIdentification.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteObjectIdentification.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteObjectIdentification.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteObjectIdentification.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteObjectIdentification
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePTPSeconds.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePTPSeconds.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 // ---- Include system wide include files ----

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePTPSeconds.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePTPSeconds.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLitePTPSeconds
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePort.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePort.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePort.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePort.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLitePort
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePortID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePortID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePortID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePortID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLitePortID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyChangedEventData.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyChangedEventData.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyChangedEventData.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyChangedEventData.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLitePropertyChangedEventData
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLitePropertyID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLitePropertyID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStream.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStream.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStream.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStream.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamConnectorID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamConnectorID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamConnectorID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamConnectorID.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamID.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /* 

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamParameters.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamParameters.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamParameters.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStreamParameters.h
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteString.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteString.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteString.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteString.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteString
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStringInABlob.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStringInABlob.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStringInABlob
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStringInABlob.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteStringInABlob.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteStringInABlob
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTemplateHelpers.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTemplateHelpers.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Helper template functions for template data types
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTemplateHelpers.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTemplateHelpers.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Helper template functions for template data types
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTimePTP.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTimePTP.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTimePTP.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteTimePTP.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteTimePTP
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteVersion.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteVersion.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteVersion.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteVersion.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteVersion
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteWorkerDataTypes.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteWorkerDataTypes.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteWorkerDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCC/ControlDataTypes/OcaLiteWorkerDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCC Worker data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcaLiteReader.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcaLiteReader.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The IOcaLiteReader interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcaLiteWriter.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcaLiteWriter.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The IOcaLiteWriter interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcfConfigure.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/IOcfConfigure.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteRoot
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteHeader.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteHeader.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteHeader.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteHeader.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteHeader
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageCommand.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageCommand.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageCommand.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageCommand.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMessageCommand
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageGeneral.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageGeneral.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageGeneral.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageGeneral.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMessageGeneral
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageKeepAlive.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageKeepAlive.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageKeepAlive.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageKeepAlive.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMessageKeepAlive
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageNotification.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMessageNotification
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageResponse.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageResponse.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageResponse.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/Messages/OcaLiteMessageResponse.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLiteMessageResponse.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandler.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandler.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteCommandHandler.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandler.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandler.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteCommandHandler class.
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandlerController.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandlerController.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteCommandHandlerController.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandlerController.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcaLiteCommandHandlerController.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLiteCommandHandlerController class.
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcfHostInterfaceDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcfHostInterfaceDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Host Interface specific data types.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcfHostInterfaceFactory.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCF/OcfHostInterfaceFactory.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The entry point to the Host Interface.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageCommand.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageCommand.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageCommand.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageCommand.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteMessageCommand
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageHeader.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageHeader.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageHeader.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageHeader.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteMessageHeader
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageKeepAlive.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageKeepAlive.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageKeepAlive.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageKeepAlive.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteMessageKeepAlive
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageNotification.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageNotification.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageNotification.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageNotification.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteMessageNotification
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageResponse.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageResponse.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageResponse.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Messages/Ocp1LiteMessageResponse.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1MessageResponse
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteConnectParameters.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteConnectParameters.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteConnectParameters
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteConnectParameters.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteConnectParameters.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The Ocp1LiteConnectParameters class.
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteNetwork
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetwork.h
@@ -1,7 +1,8 @@
 
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp.1Network
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkAddress.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkAddress.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkAddress.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkAddress.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteNetworkAddress
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkSystemInterfaceID.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkSystemInterfaceID.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkSystemInterfaceID.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteNetworkSystemInterfaceID.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteNetworkSystemInterfaceID
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteReader.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteReader.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteReader.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteReader.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteReader
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteSocketConnection.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteSocketConnection.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteSocketConnection.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteSocketConnection.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteSocketConnection
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpNetwork.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpNetwork.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpNetwork.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpNetwork.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp.1LiteUdpNetwork
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpSocketConnection.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpSocketConnection.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteUdpSocketConnection
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpSocketConnection.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteUdpSocketConnection.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteUdpSocketConnection
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteWriter.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteWriter.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteWriter.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/OCP.1/Ocp1LiteWriter.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Ocp1LiteWriter
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/Proxy/GeneralProxy.cpp
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/Proxy/GeneralProxy.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OcaLite GeneralProxy implementation.
  *

--- a/OCAMicro/OCAMicro/Src/common/OCALite/Proxy/GeneralProxy.h
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/Proxy/GeneralProxy.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The General Proxy class.
  */

--- a/OCAMicro/OCAMicro/Src/common/OCALite/makefile
+++ b/OCAMicro/OCAMicro/Src/common/OCALite/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for the OCALite proto
 #

--- a/OCAMicro/OCAMicro/Src/common/SharedLibraries/makefile
+++ b/OCAMicro/OCAMicro/Src/common/SharedLibraries/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for shared libraries
 #

--- a/OCAMicro/OCAMicro/Src/common/SharedLibraries/tinymDNS/makefile
+++ b/OCAMicro/OCAMicro/Src/common/SharedLibraries/tinymDNS/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for tinymDNS
 # 

--- a/OCAMicro/OCAMicro/Src/common/StandardLib/StandardLib.h
+++ b/OCAMicro/OCAMicro/Src/common/StandardLib/StandardLib.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Interface to the platform specific functions.
  */

--- a/OCAMicro/OCAMicro/Src/common/makefile
+++ b/OCAMicro/OCAMicro/Src/common/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for common
 #

--- a/OCAMicro/OCAMicro/Src/inc/PlatformDataTypes.h
+++ b/OCAMicro/OCAMicro/Src/inc/PlatformDataTypes.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : OCA specific data types.
  *

--- a/OCAMicro/OCAMicro/Src/makeCpp.inc
+++ b/OCAMicro/OCAMicro/Src/makeCpp.inc
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Include file for C / CPP makefiles.
 #

--- a/OCAMicro/OCAMicro/Src/makeMulti.inc
+++ b/OCAMicro/OCAMicro/Src/makeMulti.inc
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Include file for multiple makefiles.
 #

--- a/OCAMicro/OCAMicro/Src/makefile
+++ b/OCAMicro/OCAMicro/Src/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Src
 #

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Configuration/OcaLiteOcfConfiguration.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Logging/OcaLiteOcfLogger.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/Timer/OcaLiteOcfTimer.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCF/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Ocf Host Interface
 # 

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/LwIPAdapterOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/LwIPAdapterOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/LwIPAdapterOcaLite.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/LwIPAdapterOcaLite.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : LwIPAdapterOcaLite
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Network.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Ocp1HostInterfaceOcaLite.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/ZeroConf/OcaLiteOcp1Service.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Ocp1 Host Interface platform dependent elements
 # 

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description         : Makefile for OCA hostinterface
 #

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description         : Makefile for Stm32 HostInterface
 #

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/ClockGenerator/ClockGenerator.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/ClockGenerator/ClockGenerator.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/ClockGenerator/ClockGenerator.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/ClockGenerator/ClockGenerator.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Clock Generator device
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/IMember/IMember.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/IMember/IMember.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : The OcaLite member interface
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/Switch/Switch.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/Switch/Switch.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/Switch/Switch.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/Switch/Switch.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Proxy of switch device of application 
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LogicalDevices/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for LogicalDevices
 # 

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/LwIP/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/LwIP/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for LwIP
 # 

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Rs232Debug.c
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Rs232Debug.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Rs232Debug.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Rs232Debug.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Module for debugging via Rs232
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Timer.c
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Timer.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Timer.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Timer.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Contains common timer functionality.
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Watchdog.c
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Watchdog.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Watchdog.h
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/Watchdog.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : Contains common watchdog functionality
  *

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/UtilLib/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Stm32 Utillity
 # 

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/lib/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/lib/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for Stm32 libraries
 #

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for platform Stm32
 #

--- a/OCAMicro/OCAMicro/Src/platform/common/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/common/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for common platform
 #

--- a/OCAMicro/OCAMicro/Src/platform/common/tinymdns/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/common/tinymdns/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for tinymdns
 # 

--- a/OCAMicro/OCAMicro/Src/platform/common/tinymdns/tinymDNSWrapper.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/common/tinymdns/tinymDNSWrapper.cpp
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 /*

--- a/OCAMicro/OCAMicro/Src/platform/common/tinymdns/tinymDNSWrapper.h
+++ b/OCAMicro/OCAMicro/Src/platform/common/tinymdns/tinymDNSWrapper.h
@@ -1,6 +1,7 @@
 /*
  *  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  *
  *  Description         : mDNS on LwIP for OCALite
  *

--- a/OCAMicro/OCAMicro/Src/platform/makefile
+++ b/OCAMicro/OCAMicro/Src/platform/makefile
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #
 #  Description        :   Makefile for platform
 #

--- a/OCAMicro/OCAMicro/buildmicro
+++ b/OCAMicro/OCAMicro/buildmicro
@@ -1,5 +1,6 @@
 # By downloading or using this file, the user agrees to be bound by the terms of the license 
-# agreement located at http://ocaalliance.com/EULA as an original contracting party.
+# agreement located in the LICENSE file in the root of this project
+# as an original contracting party.
 #!/bin/bash
 
 export here=`pwd`

--- a/OCAMicro/system/prep_db_bin.c
+++ b/OCAMicro/system/prep_db_bin.c
@@ -1,5 +1,6 @@
 /*  By downloading or using this file, the user agrees to be bound by the terms of the license 
- *  agreement located at http://ocaalliance.com/EULA as an original contracting party.
+ *  agreement located in the LICENSE file in the root of this project
+ *  as an original contracting party.
  */
 
 //=============================================================================


### PR DESCRIPTION
The previous license header comments pointed to an outdated URL for the
text of the license agreement. The license agreement itself is already
part of this repository. This commits updates the license headers to
point to that LICENSE file.