### PR TITLE
Fixed conversion to microseconds in OcfLiteHostInterfaceSelect

### DIFF
--- a/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCACompliancyTestTool/Aes70CompliancyTestTool/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -41,7 +41,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);

--- a/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALite/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -58,7 +58,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);

--- a/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteController/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -58,7 +58,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);

--- a/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCALiteDante/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -62,7 +62,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);

--- a/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/app/OCA_BKNII/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -56,7 +56,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);

--- a/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
+++ b/OCAMicro/OCAMicro/Src/platform/Stm32/HostInterface/OCA/OCP.1/Network/OcaLiteOcp1Socket.cpp
@@ -45,7 +45,7 @@ INT32 OcfLiteHostInterfaceSelect(INT32 highest, OcfLiteSelectableSet& readset,  
     if (timeout > 0)
     {
         timeValue.tv_sec = timeout / 1000;
-        timeValue.tv_usec = timeout % 1000;
+        timeValue.tv_usec = (timeout % 1000) * 1000;
     }
     
     return select(highest + 1, &readset, &writeset, &exceptset, &timeValue);


### PR DESCRIPTION
timeout is given in milliseconds, so the remainder (timeout % 1000) needs to be multiplied by 1000 to give micoseconds.
See Bosch OCA C++ reference implementation, where this conversion is done correctly.